### PR TITLE
build: Update node version from nvmrc when publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -20,9 +20,9 @@ jobs:
     name: Run CI tests
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm test
 
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
Uses the node version from the `.nvmrc` file when publishing a release. 